### PR TITLE
lib module is missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
+#lib/
 lib64/
 parts/
 sdist/


### PR DESCRIPTION
Your project needs a lib module that is not in the repository. This may be due to the .gitignore ?